### PR TITLE
Compatibility for Water Dispensers, updated FuelAPI and my Fuel Types Framework mod

### DIFF
--- a/Contents/mods/WaterDispenser/media/scripts/WaterDispenser_items.txt
+++ b/Contents/mods/WaterDispenser/media/scripts/WaterDispenser_items.txt
@@ -17,7 +17,7 @@ module WaterDispenser {
         WorldStaticModel    = WaterJugEmpty_Ground,
         ReplaceInSecondHand = Bag_WaterJugEmpty_LHand holdingbagleft,
         ReplaceInPrimaryHand= Bag_WaterJugEmpty_RHand holdingbagright,
-        Tags                = CustomFuelContainer; Petrol_WaterDispenser_WaterJugPetrolFull,
+        Tags                = CustomFuelContainer; EmptyFuelContainer; Gasoline_WaterDispenser_WaterJugPetrolFull; Diesel_WaterDispenser_WaterJugDieselFull,
     }
 
     item WaterJugWaterFull
@@ -54,7 +54,7 @@ module WaterDispenser {
         WorldStaticModel    = WaterJugPetrolFull_Ground,
         ReplaceInSecondHand = Bag_WaterJugPetrolFull_LHand holdingbagleft,
         ReplaceInPrimaryHand= Bag_WaterJugPetrolFull_RHand holdingbagright,
-        Tags                = CustomFuelContainer; Empty_WaterDispenser_WaterJugEmpty,
+        Tags                = CustomFuelContainer; FuelType_Gasoline; Empty_WaterDispenser_WaterJugEmpty,
     }
 
 }


### PR DESCRIPTION
I remade the tags here - if you update FuelAPI as we discussed it should work without hassle as before (but will be fully compatible with my mod as well).

I also made Diesel version  of Water Jug item and will add it in my Fuel Types mod. While at it I prepared sprites for Water Dispenser with this new item. Would be perfect if you could incorporate it in upcoming updates as well!

Please contact me od Discord should you have any questions or requests.