### PR TITLE
Spanish Translation Error - ItemName_ES.txt

### DIFF
--- a/Contents/mods/WaterDispenser/media/lua/shared/Translate/ES/ItemName_ES.txt
+++ b/Contents/mods/WaterDispenser/media/lua/shared/Translate/ES/ItemName_ES.txt
@@ -1,5 +1,6 @@
 ItemName_ES = {
-    ItemName_WaterDispenser.WaterJugEmpty = "Jarra de agua vacÃ­a",
+    ItemName_WaterDispenser.WaterJugEmpty = "Jarra de agua vacía",
     ItemName_WaterDispenser.WaterJugWaterFull = "Jarra de agua con agua",
-    ItemName_WaterDispenser.WaterJugPetrolFull = "Jarra de agua con gas",
+    ItemName_WaterDispenser.WaterJugPetrolFull = "Jarra de agua con gasolina",
 }
+


### PR DESCRIPTION
In the Spanish translation. ItemName_ES.txt needs to be ANSI, there's a bad character for being in UTF-8